### PR TITLE
Refactor/k8s resources pattern

### DIFF
--- a/internal/controller/nodeGroup_controller_test.go
+++ b/internal/controller/nodeGroup_controller_test.go
@@ -46,8 +46,8 @@ func Test_NodeGroupByClusterHandler_Success(t *testing.T) {
 			},
 			K8sTestResources: []runtime.Object{
 				test.NewTestCluster("test-cluster.cluster.example.com", "testcluster-kops-cp", "KopsControlPlane", "controlplane.cluster.x-k8s.io/v1alpha1", "kops-cluster", "KopsAWSCluster", "controlplane.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestMachinePool("nodes", "test-cluster.cluster.example.com", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestKopsMachinePool("TestKopsMachinePool", "test-cluster.cluster.example.com"),
+				test.NewTestMachinePool("test-cluster.cluster.example.com-nodes", "test-cluster.cluster.example.com", "KopsMachinePool", "test-cluster.cluster.example.com-TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+				test.NewTestKopsMachinePool("test-cluster.cluster.example.com-TestKopsMachinePool", "test-cluster.cluster.example.com"),
 			},
 		},
 	}
@@ -129,7 +129,7 @@ func Test_NodeGroupByClusterHandler_Error(t *testing.T) {
 			},
 			K8sTestResources: []runtime.Object{
 				test.NewTestCluster("test-cluster.cluster.example.com", "testcluster-kops-cp", "KopsControlPlane", "controlplane.cluster.x-k8s.io/v1alpha1", "kops-cluster", "KopsAWSCluster", "controlplane.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestMachinePool("nodes", "test-cluster.cluster.example.com", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+				test.NewTestMachinePool("test-cluster.cluster.example.com-nodes", "test-cluster.cluster.example.com", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
 			},
 		},
 		{
@@ -147,7 +147,7 @@ func Test_NodeGroupByClusterHandler_Error(t *testing.T) {
 			},
 			K8sTestResources: []runtime.Object{
 				test.NewTestCluster("test-cluster.cluster.example.com", "testcluster-kops-cp", "KopsControlPlane", "controlplane.cluster.x-k8s.io/v1alpha1", "kops-cluster", "KopsAWSCluster", "controlplane.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestMachinePool("nodes", "test-cluster.cluster.example.com", "invalidKind", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+				test.NewTestMachinePool("test-cluster.cluster.example.com-nodes", "test-cluster.cluster.example.com", "invalidKind", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
 			},
 		},
 	}
@@ -208,8 +208,8 @@ func Test_NodeGroupListByClusterHandler_Success(t *testing.T) {
 			},
 			K8sTestResources: []runtime.Object{
 				test.NewTestCluster("test-cluster.cluster.example.com", "testcluster-kops-cp", "KopsControlPlane", "controlplane.cluster.x-k8s.io/v1alpha1", "kops-cluster", "KopsAWSCluster", "controlplane.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestMachinePool("nodes", "test-cluster.cluster.example.com", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestKopsMachinePool("TestKopsMachinePool", "test-cluster.cluster.example.com"),
+				test.NewTestMachinePool("test-cluster.cluster.example.com-nodes", "test-cluster.cluster.example.com", "KopsMachinePool", "test-cluster.cluster.example.com-TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+				test.NewTestKopsMachinePool("test-cluster.cluster.example.com-TestKopsMachinePool", "test-cluster.cluster.example.com"),
 			},
 		},
 		{
@@ -257,9 +257,9 @@ func Test_NodeGroupListByClusterHandler_Success(t *testing.T) {
 			},
 			K8sTestResources: []runtime.Object{
 				test.NewTestCluster("test-cluster2.cluster.example.com", "testcluster-kops-cp", "KopsControlPlane", "controlplane.cluster.x-k8s.io/v1alpha1", "kops-cluster", "KopsAWSCluster", "controlplane.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestMachinePool("nodes2", "test-cluster2.cluster.example.com", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestMachinePool("nodes3", "test-cluster2.cluster.example.com", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestKopsMachinePool("TestKopsMachinePool", "test-cluster2.cluster.example.com"),
+				test.NewTestMachinePool("test-cluster2.cluster.example.com-nodes2", "test-cluster2.cluster.example.com", "KopsMachinePool", "test-cluster2.cluster.example.com-TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+				test.NewTestMachinePool("test-cluster2.cluster.example.com-nodes3", "test-cluster2.cluster.example.com", "KopsMachinePool", "test-cluster2.cluster.example.com-TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+				test.NewTestKopsMachinePool("test-cluster2.cluster.example.com-TestKopsMachinePool", "test-cluster2.cluster.example.com"),
 			},
 		},
 	}
@@ -309,9 +309,9 @@ func Test_NodeGroupListByClusterHandler_ErrorEmptyResponse(t *testing.T) {
 			},
 			K8sTestResources: []runtime.Object{
 				test.NewTestCluster("test-cluster2.cluster.example.com", "testcluster-kops-cp", "KopsControlPlane", "controlplane.cluster.x-k8s.io/v1alpha1", "kops-cluster", "KopsAWSCluster", "controlplane.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestMachinePool("nodes2", "test-cluster2.cluster.example.com", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestMachineDeployment("nodes3", "test-cluster2.cluster.example.com", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestKopsMachinePool("TestKopsMachinePool", "test-cluster2.cluster.example.com"),
+				test.NewTestMachinePool("test-cluster2.cluster.example.com-nodes2", "test-cluster2.cluster.example.com", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+				test.NewTestMachineDeployment("test-cluster2.cluster.example.com-nodes3", "test-cluster2.cluster.example.com", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+				test.NewTestKopsMachinePool("test-cluster2.cluster.example.com-TestKopsMachinePool", "test-cluster2.cluster.example.com"),
 			},
 		},
 		{
@@ -330,9 +330,9 @@ func Test_NodeGroupListByClusterHandler_ErrorEmptyResponse(t *testing.T) {
 			K8sTestResources: []runtime.Object{
 				test.NewTestCluster("test-cluster3.cluster.example.com", "testcluster-kops-cp", "KopsControlPlane", "controlplane.cluster.x-k8s.io/v1alpha1", "kops-cluster", "KopsAWSCluster", "controlplane.cluster.x-k8s.io/v1alpha1"),
 				test.NewTestCluster("test-cluster2.cluster.example.com", "testcluster-kops-cp", "KopsControlPlane", "controlplane.cluster.x-k8s.io/v1alpha1", "kops-cluster", "KopsAWSCluster", "controlplane.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestMachinePool("nodes2", "test-cluster2.cluster.example.com", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestMachineDeployment("nodes3", "test-cluster2.cluster.example.com", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestKopsMachinePool("TestKopsMachinePool", "test-cluster2.cluster.example.com"),
+				test.NewTestMachinePool("test-cluster2.cluster.example.com-nodes2", "test-cluster2.cluster.example.com", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+				test.NewTestMachineDeployment("test-cluster2.cluster.example.com-nodes3", "test-cluster2.cluster.example.com", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+				test.NewTestKopsMachinePool("test-cluster2.cluster.example.com-TestKopsMachinePool", "test-cluster2.cluster.example.com"),
 			},
 		},
 	}

--- a/internal/k8s/cluster_test.go
+++ b/internal/k8s/cluster_test.go
@@ -56,7 +56,7 @@ func Test_GetCluster_ErrorNotFound(t *testing.T) {
 			ExpectedSuccess: nil,
 			ExpectedClientError: &clientError.ClientError{
 				ErrorCause:           nil,
-				ErrorDetailedMessage: "The requested cluster nonexistentcluster was not found in namespace nonexistentcluster!",
+				ErrorDetailedMessage: "The requested cluster nonexistentcluster was not found in namespace kubernetes-nonexistentcluster!",
 				ErrorMessage:         clientError.ResourceNotFound,
 			},
 			Request: &test.K8sRequest{

--- a/internal/k8s/nodeGroup_test.go
+++ b/internal/k8s/nodeGroup_test.go
@@ -30,8 +30,8 @@ func Test_GetNodeGroup_Success(t *testing.T) {
 				Cluster:      "TestCluster1",
 			},
 			K8sTestResources: []runtime.Object{
-				test.NewTestMachinePool("TestMachinePool", "TestCluster1", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestMachineDeployment("TestMachineDeployment", "TestCluster2", "DockerMachineTemplate", "TestDockerMachineTemplate", "infrastructure.cluster.x-k8s.io/v1beta1"),
+				test.NewTestMachinePool("TestCluster1-TestMachinePool", "TestCluster1", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+				test.NewTestMachineDeployment("TestCluster2-TestMachineDeployment", "TestCluster2", "DockerMachineTemplate", "TestDockerMachineTemplate", "infrastructure.cluster.x-k8s.io/v1beta1"),
 			},
 		},
 		{
@@ -49,8 +49,8 @@ func Test_GetNodeGroup_Success(t *testing.T) {
 				Cluster:      "TestCluster2",
 			},
 			K8sTestResources: []runtime.Object{
-				test.NewTestMachinePool("TestMachinePool", "TestCluster1", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestMachineDeployment("TestMachineDeployment", "TestCluster2", "DockerMachineTemplate", "TestDockerMachineTemplate", "infrastructure.cluster.x-k8s.io/v1beta1"),
+				test.NewTestMachinePool("TestCluster1-TestMachinePool", "TestCluster1", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+				test.NewTestMachineDeployment("TestCluster2-TestMachineDeployment", "TestCluster2", "DockerMachineTemplate", "TestDockerMachineTemplate", "infrastructure.cluster.x-k8s.io/v1beta1"),
 			},
 		},
 	}
@@ -270,15 +270,15 @@ func Test_GetMachinePool_Success(t *testing.T) {
 	testCases := []test.TestCase{
 		{
 			Name:                "GetMachinePool should return Success for MachinePool",
-			ExpectedSuccess:     test.NewTestMachinePool("TestMachinePool", "TestCluster1", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+			ExpectedSuccess:     test.NewTestMachinePool("TestCluster1-TestMachinePool", "TestCluster1", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
 			ExpectedClientError: nil,
 			Request: &test.K8sRequest{
 				ResourceName: "TestMachinePool",
 				Cluster:      "TestCluster1",
 			},
 			K8sTestResources: []runtime.Object{
-				test.NewTestMachinePool("TestMachinePool", "TestCluster1", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestMachinePool("TestMachinePool2", "TestCluster1", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+				test.NewTestMachinePool("TestCluster1-TestMachinePool", "TestCluster1", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+				test.NewTestMachinePool("TestCluster1-TestMachinePool2", "TestCluster1", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
 			},
 		},
 	}
@@ -481,15 +481,15 @@ func Test_GetMachineDeployment_Success(t *testing.T) {
 	testCases := []test.TestCase{
 		{
 			Name:                "GetMachineDeployment should return Success for MachineDeployment",
-			ExpectedSuccess:     test.NewTestMachineDeployment("TestMachineDeployment", "TestCluster1", "DockerMachineTemplate", "TestDockerMachineTemplate", "infrastructure.cluster.x-k8s.io/v1beta1"),
+			ExpectedSuccess:     test.NewTestMachineDeployment("TestCluster1-TestMachineDeployment", "TestCluster1", "DockerMachineTemplate", "TestDockerMachineTemplate", "infrastructure.cluster.x-k8s.io/v1beta1"),
 			ExpectedClientError: nil,
 			Request: &test.K8sRequest{
 				ResourceName: "TestMachineDeployment",
 				Cluster:      "TestCluster1",
 			},
 			K8sTestResources: []runtime.Object{
-				test.NewTestMachineDeployment("TestMachineDeployment", "TestCluster1", "DockerMachineTemplate", "TestDockerMachineTemplate", "infrastructure.cluster.x-k8s.io/v1beta1"),
-				test.NewTestMachineDeployment("TestMachineDeployment2", "TestCluster1", "DockerMachineTemplate", "TestDockerMachineTemplate", "infrastructure.cluster.x-k8s.io/v1beta1"),
+				test.NewTestMachineDeployment("TestCluster1-TestMachineDeployment", "TestCluster1", "DockerMachineTemplate", "TestDockerMachineTemplate", "infrastructure.cluster.x-k8s.io/v1beta1"),
+				test.NewTestMachineDeployment("TestCluster1-TestMachineDeployment2", "TestCluster1", "DockerMachineTemplate", "TestDockerMachineTemplate", "infrastructure.cluster.x-k8s.io/v1beta1"),
 			},
 		},
 	}

--- a/internal/k8s/node_infrastructure.go
+++ b/internal/k8s/node_infrastructure.go
@@ -66,12 +66,14 @@ func (k Kubernetes) GetNodeInfrastructure(clusterName, infrastructureKind string
 	return nil, clientError.NewClientError(nil, clientError.KindNotFound, fmt.Sprintf("The Kind %s could not be found", infrastructureKind))
 }
 
-// GetMachineDeployment Returns a KopsMachinepaool CR from a specific cluster
+// GetMachineDeployment Returns a KopsMachinePool CR from a specific cluster
 func (k Kubernetes) GetKopsMachinePool(clusterName string, infrastructureName string) (*clusterapikopsv1alpha1.KopsMachinePool, error) {
 	client := k.K8sAuth.DynamicClient
 
 	resource := client.Resource(KopsMachinePoolSchemaV1alpha1)
-	kopsMachinePoolRaw, err := resource.Namespace(clusterName).Get(context.TODO(), infrastructureName, metav1.GetOptions{})
+
+	namespace := GetClusterNamespace(clusterName)
+	kopsMachinePoolRaw, err := resource.Namespace(namespace).Get(context.TODO(), infrastructureName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, clientError.NewClientError(err, clientError.ResourceNotFound, fmt.Sprintf("The requested KopsMachinePool %s was not found in namespace %s!", infrastructureName, clusterName))

--- a/scripts/assets/crs/cluster_docker-cluster.yaml
+++ b/scripts/assets/crs/cluster_docker-cluster.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: docker-cluster
+  name: kubernetes-docker-cluster-example-com
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  name: docker-cluster
-  namespace: docker-cluster
+  name: docker-cluster.example.com
+  namespace: kubernetes-docker-cluster-example-com
 spec:
   clusterNetwork:
     pods:
@@ -18,30 +18,30 @@ spec:
       cidrBlocks:
       - 10.128.0.0/12
   controlPlaneEndpoint:
-    host: "docker-cluster.example.com"
+    host: "docker-cluster.example.com.example.com"
     port: 443
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: KubeadmControlPlane
-    name: docker-cluster-control-plane
-    namespace: docker-cluster
+    name: docker-cluster.example.com-control-plane
+    namespace: kubernetes-docker-cluster-example-com
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: DockerCluster
-    name: docker-cluster
-    namespace: docker-cluster
+    name: docker-cluster.example.com
+    namespace: kubernetes-docker-cluster-example-com
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerCluster
 metadata:
-  name: docker-cluster
-  namespace: docker-cluster
+  name: docker-cluster.example.com
+  namespace: kubernetes-docker-cluster-example-com
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
 metadata:
-  name: docker-cluster-control-plane
-  namespace: docker-cluster
+  name: docker-cluster.example.com-control-plane
+  namespace: kubernetes-docker-cluster-example-com
 spec:
   template:
     spec:
@@ -52,8 +52,8 @@ spec:
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:
-  name: docker-cluster-control-plane
-  namespace: docker-cluster
+  name: docker-cluster.example.com-control-plane
+  namespace: kubernetes-docker-cluster-example-com
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
@@ -80,16 +80,16 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: DockerMachineTemplate
-      name: docker-cluster-control-plane
-      namespace: docker-cluster
+      name: docker-cluster.example.com-control-plane
+      namespace: kubernetes-docker-cluster-example-com
   replicas: 3
   version: v1.22.0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
 metadata:
-  name: docker-cluster-md-0
-  namespace: docker-cluster
+  name: docker-cluster.example.com-md-0
+  namespace: kubernetes-docker-cluster-example-com
 spec:
   template:
     spec: {}
@@ -97,8 +97,8 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: docker-cluster-md-0
-  namespace: docker-cluster
+  name: docker-cluster.example.com-md-0
+  namespace: kubernetes-docker-cluster-example-com
 spec:
   template:
     spec:
@@ -111,10 +111,10 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
-  name: docker-cluster-md-0
-  namespace: docker-cluster
+  name: docker-cluster.example.com-md-0
+  namespace: kubernetes-docker-cluster-example-com
 spec:
-  clusterName: docker-cluster
+  clusterName: docker-cluster.example.com
   replicas: 3
   selector:
     matchLabels: null
@@ -124,12 +124,12 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: docker-cluster-md-0
-          namespace: docker-cluster
-      clusterName: docker-cluster
+          name: docker-cluster.example.com-md-0
+          namespace: kubernetes-docker-cluster-example-com
+      clusterName: docker-cluster.example.com
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: DockerMachineTemplate
-        name: docker-cluster-md-0
-        namespace: docker-cluster
+        name: docker-cluster.example.com-md-0
+        namespace: kubernetes-docker-cluster-example-com
       version: v1.22.0

--- a/scripts/assets/crs/cluster_kops-cluster.yaml
+++ b/scripts/assets/crs/cluster_kops-cluster.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kops-cluster
+  name: kubernetes-kops-cluster-example-com
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
@@ -9,25 +9,25 @@ metadata:
   labels:
     clusterGroup: test
     region: us-east-1
-  name: kops-cluster
-  namespace: kops-cluster
+  name: kops-cluster.example.com
+  namespace: kubernetes-kops-cluster-example-com
 spec:
   clusterNetwork:
     pods:
       cidrBlocks:
         - 192.168.0.0/16
-    serviceDomain: cluster.local
+    serviceDomain: kops-cluster.local
     services:
       cidrBlocks:
         - 10.10.0.0/12
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
     kind: KopsControlPlane
-    name: kops-cluster-control-plane
+    name: kops-cluster.example.com-control-plane
   infrastructureRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
     kind: KopsAWSCluster
-    name: kops-cluster
+    name: kops-cluster.example.com-cluster
   controlPlaneEndpoint:
     host: "kops-cluster.example.com"
     port: 443
@@ -35,8 +35,8 @@ spec:
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
 kind: KopsControlPlane
 metadata:
-  name: kops-cluster-control-plane
-  namespace: kops-cluster
+  name: kops-cluster.example.com-control-plane
+  namespace: kubernetes-kops-cluster-example-com
 spec:
   kopsClusterSpec:
     useHostCertificates: true
@@ -91,6 +91,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: KopsAWSCluster
 metadata:
-  name: kops-cluster
+  name: kops-cluster.example.com-cluster
+  namespace: kubernetes-kops-cluster-example-com
 spec:
   foo: "bar"

--- a/scripts/assets/crs/machine-deployment_docker-cluster.yaml
+++ b/scripts/assets/crs/machine-deployment_docker-cluster.yaml
@@ -1,8 +1,8 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
 metadata:
-  name: nodes
-  namespace: docker-cluster
+  name: docker-cluster.example.com-nodes
+  namespace: kubernetes-docker-cluster-example-com
 spec:
   template:
     spec: {}
@@ -10,8 +10,8 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
-  name: nodes
-  namespace: docker-cluster
+  name: docker-cluster.example.com-nodes
+  namespace: kubernetes-docker-cluster-example-com
 spec:
   clusterName: docker-cluster
   replicas: 3
@@ -23,12 +23,12 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: nodes
-          namespace: docker-cluster
+          name: docker-cluster.example.com-nodes
+          namespace: kubernetes-docker-cluster-example-com
       clusterName: docker-cluster
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: DockerMachineTemplate
-        name: nodes
-        namespace: docker-cluster
+        name: docker-cluster.example.com-nodes
+        namespace: kubernetes-docker-cluster-example-com
       version: v1.22.0

--- a/scripts/assets/crs/machinepool_kops-cluster.yaml
+++ b/scripts/assets/crs/machinepool_kops-cluster.yaml
@@ -1,26 +1,26 @@
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachinePool
 metadata:
-  name: nodes
-  namespace: kops-cluster
+  name: kops-cluster.example.com-nodes
+  namespace: kubernetes-kops-cluster-example-com
 spec:
-  clusterName: kops-cluster
+  clusterName: kops-cluster.example.com
   replicas: 0
   template:
     spec:
       bootstrap:
         dataSecretName: ""
-      clusterName: kops-cluster
+      clusterName: kops-cluster.example.com
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
         kind: KopsMachinePool
-        name: nodes
+        name: kops-cluster.example.com-nodes
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: KopsMachinePool
 metadata:
-  name: nodes
-  namespace: kops-cluster
+  name: kops-cluster.example.com-nodes
+  namespace: kubernetes-kops-cluster-example-com
 spec:
   kopsInstanceGroupSpec:
     associatePublicIp: false

--- a/test/test_kubernetes.go
+++ b/test/test_kubernetes.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	clusterapikopsv1alpha1 "github.com/topfreegames/kubernetes-kops-operator/apis/infrastructure/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,6 +11,7 @@ import (
 	"log"
 	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	clusterapiexpv1beta1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	"strings"
 )
 
 type K8sRequest struct {
@@ -39,7 +41,15 @@ func NewK8sFakeDynamicClientWithResources(resources ...runtime.Object) *fake.Fak
 	return client
 }
 
+func GetTestClusterNamespace(clusterName string) string {
+	prefix := "kubernetes"
+	clusterNamespace := strings.ReplaceAll(clusterName, ".", "-")
+	namespace := fmt.Sprintf("%s-%s", prefix, clusterNamespace)
+	return namespace
+}
+
 func NewTestCluster(name string, controlPlaneName string, controPlaneKind string, controlPlaneApiVersion string, infrastructureName string, infrastructureKind string, infrastructureApiVersion string) *clusterapiv1beta1.Cluster {
+	namespace := GetTestClusterNamespace(name)
 	testResource := clusterapiv1beta1.Cluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Cluster",
@@ -47,7 +57,7 @@ func NewTestCluster(name string, controlPlaneName string, controPlaneKind string
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: name,
+			Namespace: namespace,
 			Labels: map[string]string{
 				"region":       "us-east-1",
 				"environment":  "test",
@@ -87,6 +97,7 @@ func NewTestCluster(name string, controlPlaneName string, controPlaneKind string
 }
 
 func NewTestKopsMachinePool(name string, clusterName string) *clusterapikopsv1alpha1.KopsMachinePool {
+	namespace := GetTestClusterNamespace(clusterName)
 	testResource := clusterapikopsv1alpha1.KopsMachinePool{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "KopsMachinePool",
@@ -94,7 +105,7 @@ func NewTestKopsMachinePool(name string, clusterName string) *clusterapikopsv1al
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Namespace:   clusterName,
+			Namespace:   namespace,
 			ClusterName: clusterName,
 		},
 		Spec: clusterapikopsv1alpha1.KopsMachinePoolSpec{
@@ -111,7 +122,7 @@ func NewTestKopsMachinePool(name string, clusterName string) *clusterapikopsv1al
 }
 
 func NewTestMachinePool(name string, clusterName string, infrastructureKind string, infrastructureName string, infrastructureApiVersion string) *clusterapiexpv1beta1.MachinePool {
-
+	namespace := GetTestClusterNamespace(clusterName)
 	testResource := clusterapiexpv1beta1.MachinePool{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "MachinePool",
@@ -119,7 +130,7 @@ func NewTestMachinePool(name string, clusterName string, infrastructureKind stri
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Namespace:   clusterName,
+			Namespace:   namespace,
 			ClusterName: clusterName,
 		},
 		Spec: clusterapiexpv1beta1.MachinePoolSpec{
@@ -146,7 +157,7 @@ func NewTestMachinePool(name string, clusterName string, infrastructureKind stri
 }
 
 func NewTestMachineDeployment(name string, clusterName string, infrastructureKind string, infrastructureName string, infrastructureApiVersion string) *clusterapiv1beta1.MachineDeployment {
-
+	namespace := GetTestClusterNamespace(clusterName)
 	testResource := clusterapiv1beta1.MachineDeployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "MachineDeployment",
@@ -154,7 +165,7 @@ func NewTestMachineDeployment(name string, clusterName string, infrastructureKin
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Namespace:   clusterName,
+			Namespace:   namespace,
 			ClusterName: clusterName,
 		},
 		Spec: clusterapiv1beta1.MachineDeploymentSpec{


### PR DESCRIPTION
We decided to use the following pattern for namespace in the management cluster:
- kubernetes-cluster-name-tld-domain

e.g.
- my-cluster.example.com -> kubernetes-my-cluster-example-com

We also decided to use the following pattern for nodegroup name in the management cluster:
- cluster-full-name-nodegroup-name

e.g.
- persistent-nodes -> my-cluster.example.com-persistent-nodes
