### PR TITLE
fix: add KopsControlPlane as a possible infrastructure for the cluster

### DIFF
--- a/internal/k8s/cluster_infrastructure.go
+++ b/internal/k8s/cluster_infrastructure.go
@@ -26,7 +26,11 @@ func (k Kubernetes) GetClusterInfrastructure(infrastructureKind string) (*Cluste
 			Provider: "kops",
 		}
 		return infrastructure, nil
+	case "KopsControlPlane":
+		infrastructure = &ClusterInfrastructure{
+			Provider: "kops",
+		}
+		return infrastructure, nil
 	}
-
 	return nil, clientError.NewClientError(nil, clientError.KindNotFound, fmt.Sprintf("The Kind %s could not be found", infrastructureKind))
 }


### PR DESCRIPTION
Add KopsControlPlane as a possible infrastructure, since it can be used in cases where the cluster don't have a dedicated infrastructure resource.