### PR TITLE
fix: Add validations for cluster and NodeGroups refs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 .PHONY: all dep build test lint fix
 
-all: dep build
+all: fix lint test dep build
 
 dep:
 	@echo "  >  Making sure go.mod matches the source code"
 	go mod tidy -v
 
-build:
+build: dep
 	@echo "  >  build"
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o build/manager
 

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -26,11 +26,10 @@ func (controller ControllerConfig) ClusterHandler(c *gin.Context) {
 		} else {
 			if clientErr.ErrorMessage == clientError.ResourceNotFound {
 				clientError.ErrorHandler(c, err, "Cluster not found", http.StatusNotFound)
+			} else if clientErr.ErrorMessage == clientError.InvalidConfiguration {
+				clientError.ErrorHandler(c, err, clientErr.ErrorDetailedMessage, http.StatusInternalServerError)
 			} else {
 				clientError.ErrorHandler(c, err, "Unhandled Error", http.StatusInternalServerError)
-			}
-			if clientErr.ErrorMessage == clientError.InvalidConfiguration {
-				clientError.ErrorHandler(c, err, fmt.Sprintf("Cluster have a invalid config: %s", clientErr.ErrorDetailedMessage), http.StatusInternalServerError)
 			}
 		}
 		return

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -86,6 +86,8 @@ func (controller ControllerConfig) ClusterListHandler(c *gin.Context) {
 		} else {
 			if clientErr.ErrorMessage == clientError.ResourceNotFound {
 				clientError.ErrorHandler(c, err, "Cluster not found", http.StatusNotFound)
+			} else if clientErr.ErrorMessage == clientError.EmptyResponse {
+				clientError.ErrorHandler(c, err, "No clusters were found", http.StatusNotFound)
 			} else {
 				clientError.ErrorHandler(c, err, "Unhandled Error", http.StatusInternalServerError)
 			}
@@ -94,12 +96,6 @@ func (controller ControllerConfig) ClusterListHandler(c *gin.Context) {
 	}
 
 	for _, clusterApiCR := range clusterApiListCR.Items {
-
-		err := k8s.ValidateClusterComponents(&clusterApiCR)
-		if err != nil {
-			log.Printf("Skiping cluster %s because of invalid configuration: %v", clusterApiCR.Name, err.Error())
-			continue
-		}
 
 		controlPlane, err := controller.K8sInstance.GetControlPlane(clusterApiCR.Spec.ControlPlaneRef.Kind)
 		if err != nil {

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -98,13 +98,13 @@ func (controller ControllerConfig) ClusterListHandler(c *gin.Context) {
 
 		controlPlane, err := controller.K8sInstance.GetControlPlane(clusterApiCR.Spec.ControlPlaneRef.Kind)
 		if err != nil {
-			log.Printf("Error getting cluster controlplane for cluster %s: %v", clusterApiCR.Name, err.Error())
+			log.Printf("Error getting cluster controlplane for cluster %s: %s", clusterApiCR.Name, err.Error())
 			continue
 		}
 
 		infrastructure, err := controller.K8sInstance.GetClusterInfrastructure(clusterApiCR.Spec.InfrastructureRef.Kind)
 		if err != nil {
-			log.Printf("Error getting cluster infrastructure for %s: %v", clusterApiCR.Name, err.Error())
+			log.Printf("Error getting cluster infrastructure for %s: %s", clusterApiCR.Name, err.Error())
 			continue
 		}
 		cluster := writeClusterV1(&clusterApiCR, controlPlane, infrastructure)

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -264,7 +264,7 @@ func Test_ClusterListHandler_ErrorEmptyResponse(t *testing.T) {
 			Name:            "Error getting cluster list in clusterV1 endpoint should return empty response for invalid cluster in list",
 			ExpectedSuccess: nil,
 			ExpectedHTTPError: &apiError.ClientErrorResponse{
-				ErrorMessage: "No Clusters were found",
+				ErrorMessage: "No clusters were found",
 				ErrorType:    clientError.EmptyResponse,
 				HttpCode:     http.StatusNotFound,
 			},

--- a/internal/k8s/cluster.go
+++ b/internal/k8s/cluster.go
@@ -47,6 +47,11 @@ func (k Kubernetes) GetCluster(clusterName string) (*clusterapiv1beta1.Cluster, 
 		return nil, fmt.Errorf("could not Unmarshal Clusters JSON into clusterAPI list: %v", err)
 	}
 
+	err = ValidateClusterComponents(&cluster)
+	if err != nil {
+		return nil, err
+	}
+
 	return &cluster, nil
 }
 
@@ -81,4 +86,19 @@ func (k Kubernetes) ListClusters() (*clusterapiv1beta1.ClusterList, error) {
 	}
 
 	return &clusters, nil
+}
+
+func ValidateClusterComponents(cluster *clusterapiv1beta1.Cluster) error {
+	if cluster.Spec.InfrastructureRef == nil {
+		return clientError.NewClientError(nil, clientError.InvalidConfiguration, "Cluster doesn't have a infrastructure Reference")
+	}
+
+	if cluster.Spec.ControlPlaneRef == nil {
+		return clientError.NewClientError(nil, clientError.InvalidConfiguration, "Cluster doesn't have a ControlPlane Reference")
+	}
+
+	if !cluster.Spec.ControlPlaneEndpoint.IsValid() {
+		return clientError.NewClientError(nil, clientError.InvalidConfiguration, "Cluster doesn't have a valid ControlPlane endpoint")
+	}
+	return nil
 }

--- a/internal/k8s/cluster.go
+++ b/internal/k8s/cluster.go
@@ -50,7 +50,7 @@ func (k Kubernetes) GetCluster(clusterName string) (*clusterapiv1beta1.Cluster, 
 
 	err = ValidateClusterComponents(&cluster)
 	if err != nil {
-		return nil, err
+		return nil, clientError.NewClientError(err, clientError.InvalidConfiguration, fmt.Sprintf("Cluster %s have an invalid configuration", clusterName))
 	}
 
 	return &cluster, nil

--- a/internal/k8s/cluster.go
+++ b/internal/k8s/cluster.go
@@ -32,7 +32,7 @@ func (k Kubernetes) GetCluster(clusterName string) (*clusterapiv1beta1.Cluster, 
 		if errors.IsNotFound(err) {
 			return nil, clientError.NewClientError(err, clientError.ResourceNotFound, fmt.Sprintf("The requested cluster %s was not found in namespace %s!", clusterName, namespace))
 		} else if statusError, isStatus := err.(*errors.StatusError); isStatus {
-			return nil, fmt.Errorf("Error getting Cluster from Kubernetes API: %v\n", statusError.ErrStatus.Message)
+			return nil, fmt.Errorf("Error getting Cluster from Kubernetes API: %s\n", statusError.ErrStatus.Message)
 		}
 		return nil, fmt.Errorf("Kube go-client Error: %v\n", err)
 	}
@@ -63,9 +63,9 @@ func (k Kubernetes) ListClusters() (*clusterapiv1beta1.ClusterList, error) {
 	clustersRaw, err := client.Resource(ClusterResourceSchemaV1beta1).List(context.TODO(), metav1.ListOptions{})
 
 	if errors.IsNotFound(err) {
-		return nil, clientError.NewClientError(err, clientError.ResourceNotFound, "Could not find any cluster in the Kubernetes API")
+		return nil, clientError.NewClientError(err, clientError.ResourceNotFound, "could not find any cluster in the Kubernetes API")
 	} else if statusError, isStatus := err.(*errors.StatusError); isStatus {
-		return nil, fmt.Errorf("Error getting Cluster from Server API %v\n", statusError.ErrStatus.Message)
+		return nil, fmt.Errorf("Error getting Cluster from Server API %s\n", statusError.ErrStatus.Message)
 	} else if err != nil {
 		return nil, fmt.Errorf("Kube go-client Error: %v\n", err)
 	}
@@ -95,7 +95,7 @@ func (k Kubernetes) ListClusters() (*clusterapiv1beta1.ClusterList, error) {
 	for _, cluster := range clusters.Items {
 		err := ValidateClusterComponents(&cluster)
 		if err != nil {
-			log.Printf("Skiping cluster %s because of invalid configuration: %v", cluster.Name, err.Error())
+			log.Printf("Skipping cluster %s because of invalid configuration: %s", cluster.Name, err.Error())
 			continue
 		}
 		clustersValidated.Items = append(clustersValidated.Items, cluster)
@@ -110,7 +110,7 @@ func (k Kubernetes) ListClusters() (*clusterapiv1beta1.ClusterList, error) {
 
 func ValidateClusterComponents(cluster *clusterapiv1beta1.Cluster) error {
 	if cluster.Spec.InfrastructureRef == nil {
-		return clientError.NewClientError(nil, clientError.InvalidConfiguration, "Cluster doesn't have a infrastructure Reference")
+		return clientError.NewClientError(nil, clientError.InvalidConfiguration, "Cluster doesn't have an infrastructure Reference")
 	}
 
 	if cluster.Spec.ControlPlaneRef == nil {

--- a/internal/k8s/cluster_test.go
+++ b/internal/k8s/cluster_test.go
@@ -71,7 +71,7 @@ func Test_GetCluster_Error(t *testing.T) {
 			ExpectedSuccess: nil,
 			ExpectedClientError: &clientError.ClientError{
 				ErrorCause:           nil,
-				ErrorDetailedMessage: "Cluster doesn't have a ControlPlane Reference",
+				ErrorDetailedMessage: "Cluster testcluster have an invalid configuration",
 				ErrorMessage:         clientError.InvalidConfiguration,
 			},
 			Request: &test.K8sRequest{
@@ -86,7 +86,7 @@ func Test_GetCluster_Error(t *testing.T) {
 			ExpectedSuccess: nil,
 			ExpectedClientError: &clientError.ClientError{
 				ErrorCause:           nil,
-				ErrorDetailedMessage: "Cluster doesn't have a infrastructure Reference",
+				ErrorDetailedMessage: "Cluster testcluster have an invalid configuration",
 				ErrorMessage:         clientError.InvalidConfiguration,
 			},
 			Request: &test.K8sRequest{

--- a/internal/k8s/cluster_test.go
+++ b/internal/k8s/cluster_test.go
@@ -271,7 +271,7 @@ func Test_ValidateClusterComponents_Error(t *testing.T) {
 			ExpectedSuccess: nil,
 			ExpectedClientError: &clientError.ClientError{
 				ErrorCause:           nil,
-				ErrorDetailedMessage: "Cluster doesn't have a infrastructure Reference",
+				ErrorDetailedMessage: "Cluster doesn't have an infrastructure Reference",
 				ErrorMessage:         clientError.InvalidConfiguration,
 			},
 			K8sTestResources: []runtime.Object{

--- a/internal/k8s/cluster_test.go
+++ b/internal/k8s/cluster_test.go
@@ -49,7 +49,7 @@ func Test_GetCluster_Success(t *testing.T) {
 	}
 }
 
-func Test_GetCluster_ErrorNotFound(t *testing.T) {
+func Test_GetCluster_Error(t *testing.T) {
 	testCases := []test.TestCase{
 		{
 			Name:            "GetCluster should return Error for non-existent cluster",
@@ -64,6 +64,36 @@ func Test_GetCluster_ErrorNotFound(t *testing.T) {
 			},
 			K8sTestResources: []runtime.Object{
 				test.NewTestCluster("testcluster", "testcluster-kops-cp", "KopsControlPlane", "controlplane.cluster.x-k8s.io/v1alpha1", "kops-cluster", "KopsAWSCluster", "controlplane.cluster.x-k8s.io/v1alpha1"),
+			},
+		},
+		{
+			Name:            "GetCluster should return Error for cluster without controlplane",
+			ExpectedSuccess: nil,
+			ExpectedClientError: &clientError.ClientError{
+				ErrorCause:           nil,
+				ErrorDetailedMessage: "Cluster doesn't have a ControlPlane Reference",
+				ErrorMessage:         clientError.InvalidConfiguration,
+			},
+			Request: &test.K8sRequest{
+				ResourceName: "testcluster",
+			},
+			K8sTestResources: []runtime.Object{
+				test.NewTestCluster("testcluster", "", "", "", "kops-cluster", "KopsAWSCluster", "controlplane.cluster.x-k8s.io/v1alpha1"),
+			},
+		},
+		{
+			Name:            "GetCluster should return Error for cluster without infrastructure",
+			ExpectedSuccess: nil,
+			ExpectedClientError: &clientError.ClientError{
+				ErrorCause:           nil,
+				ErrorDetailedMessage: "Cluster doesn't have a infrastructure Reference",
+				ErrorMessage:         clientError.InvalidConfiguration,
+			},
+			Request: &test.K8sRequest{
+				ResourceName: "testcluster",
+			},
+			K8sTestResources: []runtime.Object{
+				test.NewTestCluster("testcluster", "testcluster-kops-cp", "KopsControlPlane", "controlplane.cluster.x-k8s.io/v1alpha1", "", "", ""),
 			},
 		},
 	}
@@ -143,6 +173,81 @@ func Test_ListClusters_Success(t *testing.T) {
 			response, err := k.ListClusters()
 			assert.NilError(t, err)
 			assert.Assert(t, reflect.DeepEqual(expectedInfra, response))
+		})
+	}
+}
+
+func Test_ValidateClusterComponents_Success(t *testing.T) {
+	testCases := []test.TestCase{
+		{
+			Name:                "ValidateClusterComponents Should return success for a valid cluster",
+			ExpectedClientError: nil,
+			Request: &test.K8sRequest{
+				ResourceName: "testcluster",
+			},
+			K8sTestResources: []runtime.Object{
+				test.NewTestCluster("testcluster", "testcluster-kops-cp", "KopsControlPlane", "controlplane.cluster.x-k8s.io/v1alpha1", "kops-cluster", "KopsAWSCluster", "controlplane.cluster.x-k8s.io/v1alpha1"),
+			},
+		},
+	}
+
+	fakeClient := test.NewK8sFakeDynamicClient()
+	k := &Kubernetes{K8sAuth: &Auth{
+		DynamicClient: fakeClient,
+	}}
+
+	for _, testCase := range testCases {
+		request := testCase.GetK8sRequest()
+		k.K8sAuth.DynamicClient = test.NewK8sFakeDynamicClientWithResources(testCase.K8sTestResources...)
+
+		cluster, _ := k.GetCluster(request.ResourceName)
+		t.Run(testCase.Name, func(t *testing.T) {
+			err := ValidateClusterComponents(cluster)
+			assert.NilError(t, err)
+		})
+	}
+}
+
+func Test_ValidateClusterComponents_Error(t *testing.T) {
+	testCases := []test.TestCase{
+		{
+			Name:            "Should return an error for a cluster without controplane",
+			ExpectedSuccess: nil,
+			ExpectedClientError: &clientError.ClientError{
+				ErrorCause:           nil,
+				ErrorDetailedMessage: "Cluster doesn't have a ControlPlane Reference",
+				ErrorMessage:         clientError.InvalidConfiguration,
+			},
+			K8sTestResources: []runtime.Object{
+				test.NewTestCluster("testcluster", "", "", "", "kops-cluster", "KopsAWSCluster", "controlplane.cluster.x-k8s.io/v1alpha1"),
+			},
+		},
+		{
+			Name:            "Should return an error for a cluster without infrastructure",
+			ExpectedSuccess: nil,
+			ExpectedClientError: &clientError.ClientError{
+				ErrorCause:           nil,
+				ErrorDetailedMessage: "Cluster doesn't have a infrastructure Reference",
+				ErrorMessage:         clientError.InvalidConfiguration,
+			},
+			K8sTestResources: []runtime.Object{
+				test.NewTestCluster("testcluster", "testcluster-kops-cp", "KopsControlPlane", "controlplane.cluster.x-k8s.io/v1alpha1", "", "", ""),
+			},
+		},
+	}
+
+	fakeClient := test.NewK8sFakeDynamicClient()
+	k := &Kubernetes{K8sAuth: &Auth{
+		DynamicClient: fakeClient,
+	}}
+
+	for _, testCase := range testCases {
+		k.K8sAuth.DynamicClient = test.NewK8sFakeDynamicClientWithResources(testCase.K8sTestResources...)
+		cluster, _ := testCase.K8sTestResources[0].(*clusterapiv1beta1.Cluster)
+		t.Run(testCase.Name, func(t *testing.T) {
+			err := ValidateClusterComponents(cluster)
+			assert.ErrorContains(t, err, testCase.ExpectedClientError.Error())
+			assert.Assert(t, test.AssertClientError(err, testCase.ExpectedClientError))
 		})
 	}
 }

--- a/internal/k8s/nodeGroup_test.go
+++ b/internal/k8s/nodeGroup_test.go
@@ -759,7 +759,7 @@ func Test_ValidateMachineTemplateComponents_Error(t *testing.T) {
 			ExpectedSuccess: nil,
 			ExpectedClientError: &clientError.ClientError{
 				ErrorCause:           nil,
-				ErrorDetailedMessage: "MachineTemplate doesn't have a infrastructure Reference",
+				ErrorDetailedMessage: "MachineTemplate doesn't have an infrastructure Reference",
 				ErrorMessage:         clientError.InvalidConfiguration,
 			},
 			K8sTestResources: []runtime.Object{

--- a/internal/k8s/nodeGroup_test.go
+++ b/internal/k8s/nodeGroup_test.go
@@ -76,7 +76,7 @@ func Test_GetNodeGroup_Success(t *testing.T) {
 	}
 }
 
-func Test_GetNodeGroup_ErrorNotFound(t *testing.T) {
+func Test_GetNodeGroup_Error(t *testing.T) {
 	testCases := []test.TestCase{
 		{
 			Name:            "GetNodeGroup should return Error for non-existent resource",
@@ -108,8 +108,24 @@ func Test_GetNodeGroup_ErrorNotFound(t *testing.T) {
 				Cluster:      "TestCluster3",
 			},
 			K8sTestResources: []runtime.Object{
-				test.NewTestMachinePool("TestMachinePool", "TestCluster1", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
-				test.NewTestMachineDeployment("TestMachineDeployment", "TestCluster2", "DockerMachineTemplate", "TestDockerMachineTemplate", "infrastructure.cluster.x-k8s.io/v1beta1"),
+				test.NewTestMachinePool("TestCluster1-TestMachinePool", "TestCluster1", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+				test.NewTestMachineDeployment("TestCluster2-TestMachineDeployment", "TestCluster2", "DockerMachineTemplate", "TestDockerMachineTemplate", "infrastructure.cluster.x-k8s.io/v1beta1"),
+			},
+		},
+		{
+			Name:            "GetNodeGroup should return Error for node without infrastructure",
+			ExpectedSuccess: nil,
+			ExpectedClientError: &clientError.ClientError{
+				ErrorCause:           nil,
+				ErrorDetailedMessage: "NodeGroup TestMachinePool configuration is invalid",
+				ErrorMessage:         clientError.InvalidConfiguration,
+			},
+			Request: &test.K8sRequest{
+				ResourceName: "TestMachinePool",
+				Cluster:      "TestCluster1",
+			},
+			K8sTestResources: []runtime.Object{
+				test.NewTestMachinePool("TestCluster1-TestMachinePool", "TestCluster1", "", "", ""),
 			},
 		},
 	}
@@ -212,7 +228,7 @@ func Test_ListNodeGroup_Success(t *testing.T) {
 	}
 }
 
-func Test_ListNodeGroup_ErrorEmptyResponse(t *testing.T) {
+func Test_ListNodeGroup_Error(t *testing.T) {
 	testCases := []test.TestCase{
 		{
 			Name:            "ListNodeGroup should return Error for non-existent resources in cluster",
@@ -245,6 +261,22 @@ func Test_ListNodeGroup_ErrorEmptyResponse(t *testing.T) {
 			K8sTestResources: []runtime.Object{
 				test.NewTestMachinePool("TestMachinePool", "TestCluster1", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
 				test.NewTestMachineDeployment("TestMachineDeployment", "TestCluster2", "DockerMachineTemplate", "TestDockerMachineTemplate", "infrastructure.cluster.x-k8s.io/v1beta1"),
+			},
+		},
+		{
+			Name:            "ListNodeGroup should return EmptyResponse for nodegroup without infrastructure",
+			ExpectedSuccess: nil,
+			ExpectedClientError: &clientError.ClientError{
+				ErrorCause:           nil,
+				ErrorDetailedMessage: "No valid NodeGroups were found in the cluster TestCluster2, some Nodegroups have invalid configuration",
+				ErrorMessage:         clientError.EmptyResponse,
+			},
+			Request: &test.K8sRequest{
+				Cluster: "TestCluster2",
+			},
+			K8sTestResources: []runtime.Object{
+				test.NewTestMachinePool("TestMachinePool", "TestCluster1", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+				test.NewTestMachineDeployment("TestCluster2-TestMachineDeployment", "TestCluster2", "", "", ""),
 			},
 		},
 	}
@@ -304,7 +336,7 @@ func Test_GetMachinePool_Success(t *testing.T) {
 	}
 }
 
-func Test_GetMachinePool_ErrorNotFound(t *testing.T) {
+func Test_GetMachinePool_Error(t *testing.T) {
 	testCases := []test.TestCase{
 		{
 			Name:            "GetMachinepool should return Error for non-existent resource",
@@ -319,7 +351,7 @@ func Test_GetMachinePool_ErrorNotFound(t *testing.T) {
 				Cluster:      "TestCluster1",
 			},
 			K8sTestResources: []runtime.Object{
-				test.NewTestMachinePool("TestMachinePool", "TestCluster1", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+				test.NewTestMachinePool("TestCluster1-TestMachinePool", "TestCluster1", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
 			},
 		},
 		{
@@ -335,7 +367,23 @@ func Test_GetMachinePool_ErrorNotFound(t *testing.T) {
 				Cluster:      "TestCluster3",
 			},
 			K8sTestResources: []runtime.Object{
-				test.NewTestMachinePool("TestMachinePool", "TestCluster1", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+				test.NewTestMachinePool("TestCluster1-TestMachinePool", "TestCluster1", "KopsMachinePool", "TestKopsMachinePool", "infrastructure.cluster.x-k8s.io/v1alpha1"),
+			},
+		},
+		{
+			Name:            "GetMachinepool should return Error for a machinePool without infrastructure",
+			ExpectedSuccess: nil,
+			ExpectedClientError: &clientError.ClientError{
+				ErrorCause:           nil,
+				ErrorDetailedMessage: "MachinePool TestCluster1-TestMachinePool doesn't have a valid configuration",
+				ErrorMessage:         clientError.InvalidConfiguration,
+			},
+			Request: &test.K8sRequest{
+				ResourceName: "TestMachinePool",
+				Cluster:      "TestCluster1",
+			},
+			K8sTestResources: []runtime.Object{
+				test.NewTestMachinePool("TestCluster1-TestMachinePool", "TestCluster1", "", "", ""),
 			},
 		},
 	}
@@ -424,7 +472,7 @@ func Test_ListMachinePool_Success(t *testing.T) {
 	}
 }
 
-func Test_ListMachinePool_ErrorEmptyResponse(t *testing.T) {
+func Test_ListMachinePool_Error(t *testing.T) {
 	testCases := []test.TestCase{
 		{
 			Name:            "ListMachinePool should return Error for non-existent resources in cluster",
@@ -515,7 +563,7 @@ func Test_GetMachineDeployment_Success(t *testing.T) {
 	}
 }
 
-func Test_GetMachineDeployment_ErrorNotFound(t *testing.T) {
+func Test_GetMachineDeployment_Error(t *testing.T) {
 	testCases := []test.TestCase{
 		{
 			Name:            "GetMachineDeployment should return Error for non-existent resource",
@@ -530,7 +578,7 @@ func Test_GetMachineDeployment_ErrorNotFound(t *testing.T) {
 				Cluster:      "TestCluster1",
 			},
 			K8sTestResources: []runtime.Object{
-				test.NewTestMachineDeployment("TestMachineDeployment", "TestCluster1", "DockerMachineTemplate", "TestDockerMachineTemplate", "infrastructure.cluster.x-k8s.io/v1beta1"),
+				test.NewTestMachineDeployment("TestCluster1-TestMachineDeployment", "TestCluster1", "DockerMachineTemplate", "TestDockerMachineTemplate", "infrastructure.cluster.x-k8s.io/v1beta1"),
 			},
 		},
 		{
@@ -546,7 +594,23 @@ func Test_GetMachineDeployment_ErrorNotFound(t *testing.T) {
 				Cluster:      "TestCluster3",
 			},
 			K8sTestResources: []runtime.Object{
-				test.NewTestMachineDeployment("TestMachineDeployment", "TestCluster1", "DockerMachineTemplate", "TestDockerMachineTemplate", "infrastructure.cluster.x-k8s.io/v1beta1"),
+				test.NewTestMachineDeployment("TestCluster1-TestMachineDeployment", "TestCluster1", "DockerMachineTemplate", "TestDockerMachineTemplate", "infrastructure.cluster.x-k8s.io/v1beta1"),
+			},
+		},
+		{
+			Name:            "GetMachinepool should return Error for a machinePool without infrastructure",
+			ExpectedSuccess: nil,
+			ExpectedClientError: &clientError.ClientError{
+				ErrorCause:           nil,
+				ErrorDetailedMessage: "MachineDeployment TestCluster1-TestMachineDeployment doesn't have a valid configuration",
+				ErrorMessage:         clientError.InvalidConfiguration,
+			},
+			Request: &test.K8sRequest{
+				ResourceName: "TestMachineDeployment",
+				Cluster:      "TestCluster1",
+			},
+			K8sTestResources: []runtime.Object{
+				test.NewTestMachineDeployment("TestCluster1-TestMachineDeployment", "TestCluster1", "", "", ""),
 			},
 		},
 	}
@@ -635,7 +699,7 @@ func Test_ListMachineDeployment_Success(t *testing.T) {
 	}
 }
 
-func Test_ListMachineDeployment_ErrorEmptyResponse(t *testing.T) {
+func Test_ListMachineDeployment_Error(t *testing.T) {
 	testCases := []test.TestCase{
 		{
 			Name:            "ListMachineDeployment should return Error for non-existent resources in cluster",
@@ -682,6 +746,38 @@ func Test_ListMachineDeployment_ErrorEmptyResponse(t *testing.T) {
 
 		t.Run(testCase.Name, func(t *testing.T) {
 			_, err := k.ListMachineDeployment(request.Cluster)
+			assert.ErrorContains(t, err, testCase.ExpectedClientError.Error())
+			assert.Assert(t, test.AssertClientError(err, testCase.ExpectedClientError))
+		})
+	}
+}
+
+func Test_ValidateMachineTemplateComponents_Error(t *testing.T) {
+	testCases := []test.TestCase{
+		{
+			Name:            "Should return an error for a NodeGroup without infrastructure",
+			ExpectedSuccess: nil,
+			ExpectedClientError: &clientError.ClientError{
+				ErrorCause:           nil,
+				ErrorDetailedMessage: "MachineTemplate doesn't have a infrastructure Reference",
+				ErrorMessage:         clientError.InvalidConfiguration,
+			},
+			K8sTestResources: []runtime.Object{
+				test.NewTestMachinePool("TestMachinePool", "TestCluster2", "", "", ""),
+			},
+		},
+	}
+
+	fakeClient := test.NewK8sFakeDynamicClient()
+	k := &Kubernetes{K8sAuth: &Auth{
+		DynamicClient: fakeClient,
+	}}
+
+	for _, testCase := range testCases {
+		k.K8sAuth.DynamicClient = test.NewK8sFakeDynamicClientWithResources(testCase.K8sTestResources...)
+		machinePool, _ := testCase.K8sTestResources[0].(*clusterapiexpv1beta1.MachinePool)
+		t.Run(testCase.Name, func(t *testing.T) {
+			err := ValidateMachineTemplateComponents(machinePool.Spec.Template)
 			assert.ErrorContains(t, err, testCase.ExpectedClientError.Error())
 			assert.Assert(t, test.AssertClientError(err, testCase.ExpectedClientError))
 		})

--- a/internal/k8s/node_infrastructure.go
+++ b/internal/k8s/node_infrastructure.go
@@ -46,7 +46,7 @@ func (k Kubernetes) GetNodeInfrastructure(clusterName, infrastructureKind string
 		if err != nil {
 			clientErr, ok := err.(*clientError.ClientError)
 			if !ok {
-				return nil, fmt.Errorf("an error has ocurred while feching kopsmachinepool infrastructure: %v", err)
+				return nil, fmt.Errorf("an error has ocurred while feching kopsmachinepool infrastructure: %s", err.Error())
 			}
 			return nil, clientError.NewClientError(err, clientErr.ErrorMessage, "Could not retrieve the infrastructure")
 		}
@@ -78,7 +78,7 @@ func (k Kubernetes) GetKopsMachinePool(clusterName string, infrastructureName st
 		if errors.IsNotFound(err) {
 			return nil, clientError.NewClientError(err, clientError.ResourceNotFound, fmt.Sprintf("The requested KopsMachinePool %s was not found in namespace %s!", infrastructureName, clusterName))
 		} else if statusError, isStatus := err.(*errors.StatusError); isStatus {
-			return nil, fmt.Errorf("Error getting kopsmachinepool from Kubernetes API: %v\n", statusError.ErrStatus.Message)
+			return nil, fmt.Errorf("Error getting kopsmachinepool from Kubernetes API: %s\n", statusError.ErrStatus.Message)
 		}
 		return nil, fmt.Errorf("Kube go-client Error: %v\n", err)
 	}

--- a/test/test_kubernetes.go
+++ b/test/test_kubernetes.go
@@ -49,6 +49,30 @@ func GetTestClusterNamespace(clusterName string) string {
 }
 
 func NewTestCluster(name string, controlPlaneName string, controPlaneKind string, controlPlaneApiVersion string, infrastructureName string, infrastructureKind string, infrastructureApiVersion string) *clusterapiv1beta1.Cluster {
+
+	var (
+		controlplaneRef   *corev1.ObjectReference
+		infrastructureRef *corev1.ObjectReference
+	)
+
+	if controlPlaneName != "" {
+		controlplaneRef = &corev1.ObjectReference{
+			Kind:       controPlaneKind,
+			Namespace:  name,
+			Name:       controlPlaneName,
+			APIVersion: controlPlaneApiVersion,
+		}
+	}
+
+	if infrastructureName != "" {
+		infrastructureRef = &corev1.ObjectReference{
+			Kind:       infrastructureKind,
+			Namespace:  name,
+			Name:       infrastructureName,
+			APIVersion: infrastructureApiVersion,
+		}
+	}
+
 	namespace := GetTestClusterNamespace(name)
 	testResource := clusterapiv1beta1.Cluster{
 		TypeMeta: metav1.TypeMeta{
@@ -77,18 +101,8 @@ func NewTestCluster(name string, controlPlaneName string, controPlaneKind string
 				Host: "api." + name + ".cluster.example.com",
 				Port: 443,
 			},
-			ControlPlaneRef: &corev1.ObjectReference{
-				Kind:       controPlaneKind,
-				Namespace:  name,
-				Name:       controlPlaneName,
-				APIVersion: controlPlaneApiVersion,
-			},
-			InfrastructureRef: &corev1.ObjectReference{
-				Kind:       infrastructureKind,
-				Namespace:  name,
-				Name:       infrastructureName,
-				APIVersion: infrastructureApiVersion,
-			},
+			ControlPlaneRef:   controlplaneRef,
+			InfrastructureRef: infrastructureRef,
 		},
 		Status: clusterapiv1beta1.ClusterStatus{},
 	}

--- a/test/test_kubernetes.go
+++ b/test/test_kubernetes.go
@@ -136,6 +136,17 @@ func NewTestKopsMachinePool(name string, clusterName string) *clusterapikopsv1al
 }
 
 func NewTestMachinePool(name string, clusterName string, infrastructureKind string, infrastructureName string, infrastructureApiVersion string) *clusterapiexpv1beta1.MachinePool {
+	var infrastructureRef corev1.ObjectReference
+
+	if infrastructureName != "" {
+		infrastructureRef = corev1.ObjectReference{
+			Kind:       infrastructureKind,
+			Namespace:  clusterName,
+			Name:       infrastructureName,
+			APIVersion: infrastructureApiVersion,
+		}
+	}
+
 	namespace := GetTestClusterNamespace(clusterName)
 	testResource := clusterapiexpv1beta1.MachinePool{
 		TypeMeta: metav1.TypeMeta{
@@ -153,14 +164,9 @@ func NewTestMachinePool(name string, clusterName string, infrastructureKind stri
 			Template: clusterapiv1beta1.MachineTemplateSpec{
 				ObjectMeta: clusterapiv1beta1.ObjectMeta{},
 				Spec: clusterapiv1beta1.MachineSpec{
-					ClusterName: clusterName,
-					Bootstrap:   clusterapiv1beta1.Bootstrap{},
-					InfrastructureRef: corev1.ObjectReference{
-						Kind:       infrastructureKind,
-						Namespace:  clusterName,
-						Name:       infrastructureName,
-						APIVersion: infrastructureApiVersion,
-					},
+					ClusterName:       clusterName,
+					Bootstrap:         clusterapiv1beta1.Bootstrap{},
+					InfrastructureRef: infrastructureRef,
 				},
 			},
 		},


### PR DESCRIPTION
Add validations to avoid crashes due to a nil pointer when the underlying configuration is invalid.
- Cluster without ControlPlaneRef or InfrastructureRef
- NodeGroups (MachineDeployment, MachinePool) without InfrastructureRef