### PR TITLE
chore: install git in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:alpine as builder
 
-RUN apk add --no-cache make
+RUN apk add --no-cache make git
 
 COPY . /kaas
 WORKDIR /kaas


### PR DESCRIPTION
This is needed because Swagger needs to pull some deps